### PR TITLE
Create a config loader

### DIFF
--- a/src/walk_watcher/walkwatcher.py
+++ b/src/walk_watcher/walkwatcher.py
@@ -6,6 +6,7 @@ import os
 import re
 import sqlite3
 from collections.abc import Generator
+from configparser import ConfigParser
 from contextlib import closing
 from datetime import datetime
 from types import TracebackType
@@ -75,6 +76,76 @@ class File:
             raise ValueError("Metric name cannot contain whitespace")
 
         return f"{metric_name},oldest.file.seconds={self.root} {self.age_seconds}"
+
+
+class WatcherConfig:
+    """Configuration for the Watcher."""
+
+    logger = logging.getLogger("walk_watcher.WatcherConfig")
+
+    def __init__(self, filepath: str) -> None:
+        """Load the configuration from the given file."""
+        self._config = ConfigParser()
+        success = self._config.read(filepath)
+
+        if not success:
+            raise ValueError(f"Could not read config file at {filepath}")
+
+        self.logger.debug("Loaded config from %s", filepath)
+
+    @property
+    def database_path(self) -> str:
+        """Return the path to the database file, or ":memory:" if not set."""
+        return self._config.get("system", "path", fallback=":memory:")
+
+    @property
+    def max_is_running_seconds(self) -> int:
+        """Return the maximum age of the is_running flag in seconds."""
+        return self._config.getint("system", "max_is_running_seconds", fallback=300)
+
+    @property
+    def oldest_directory_row_days(self) -> int:
+        """Return the maximum age of a directory row in days."""
+        return self._config.getint("system", "oldest_directory_row_days", fallback=30)
+
+    @property
+    def oldest_file_row_days(self) -> int:
+        """Return the maximum age of a file row in days."""
+        return self._config.getint("system", "oldest_file_row_days", fallback=30)
+
+    @property
+    def max_files_per_directory(self) -> int:
+        """Return the maximum number of files to store per directory."""
+        return self._config.getint("system", "max_files_per_directory", fallback=1000)
+
+    @property
+    def metric_name(self) -> str:
+        """Return the name of the metric to use."""
+        return self._config.get("watcher", "metric_name", fallback="walk_watcher")
+
+    @property
+    def root_directory(self) -> str:
+        """Return the root directory to watch. Will raise if not set."""
+        return self._config.get("watcher", "root_directory")
+
+    @property
+    def remove_prefix(self) -> str | None:
+        """Return the prefix to remove from the root directory when reporting."""
+        return self._config.get("watcher", "remove_prefix", fallback=None)
+
+    @property
+    def exlude_directory_pattern(self) -> str | None:
+        """Return the pattern to exclude directories from the walk."""
+        config_line = self._config.get("watcher", "exclude_directories", fallback="")
+        lines = [line.strip() for line in config_line.splitlines() if line.strip()]
+        return "|".join(lines) or None
+
+    @property
+    def exclude_file_pattern(self) -> str | None:
+        """Return the pattern to exclude files from the walk."""
+        config_line = self._config.get("watcher", "exclude_files", fallback="")
+        lines = [line.strip() for line in config_line.splitlines() if line.strip()]
+        return "|".join(lines) or None
 
 
 class StoreDB:

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,0 +1,20 @@
+[system]
+database_path = :memory:
+max_is_running_seconds = 60
+oldest_directory_row_days = 15
+oldest_file_row_days = 15
+max_files_per_directory = 10000
+
+[watcher]
+# Metric names cannot contain spaces or commas.
+metric_name = test_watcher
+root_directory = tests/fixture
+remove_prefix = tests/
+
+# Exclude directories and files from being watched.
+# The following are regular expressions and are matched against the full path.
+# Multiline values are combined into a single regular expression.
+exclude_directories = directory02
+    fixture\/$
+
+exclude_files = file.*

--- a/tests/watcherconfig_test.py
+++ b/tests/watcherconfig_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from walk_watcher.walkwatcher import WatcherConfig
+
+CONFIG_PATH = "tests/test_config.ini"
+
+
+def test_watcherconfig_raises_on_invalid_config_path() -> None:
+    with pytest.raises(ValueError):
+        WatcherConfig("foo/bar")
+
+
+def test_watcherconfig_loads_test_fixture_completely() -> None:
+    config = WatcherConfig(CONFIG_PATH)
+
+    assert config.database_path == ":memory:"
+    assert config.max_is_running_seconds == 60
+    assert config.oldest_directory_row_days == 15
+    assert config.oldest_file_row_days == 15
+    assert config.max_files_per_directory == 10_000
+
+    assert config.metric_name == "test_watcher"
+    assert config.root_directory == "tests/fixture"
+    assert config.remove_prefix == "tests/"
+
+    assert config.exlude_directory_pattern == r"directory02|fixture\/$"
+    assert config.exclude_file_pattern == "file.*"


### PR DESCRIPTION
The loader controls the main process. Multiple configuration files are expected for multiple requirements. It is recommended though not enforced that separate database files be used for each config.