### PR TITLE
Remove 'remove_prefix' from config - redundant control

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,12 @@ Spaces are not permitted.
 
 ### \[watcher\]
 
-| key                   | value                                                                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `metric_name`         | Name of the metric being emitted                                                                                                |
-| `root_directory`      | Location of the directory to scan for files                                                                                     |
-| `remove_prefix`       | Removes defined prefix from the `root`. Example, setting as `/home/process` would transform `/home/process/queues` to `/queues` |
-| `exclude_directories` | regex expression of directories to exclude from walking                                                                         |
-| `exclude_files`       | regex expression of files to exclude from tracking                                                                              |
+| key                   | value                                                   |
+| --------------------- | ------------------------------------------------------- |
+| `metric_name`         | Name of the metric being emitted                        |
+| `root_directories`    | Location of the directories to scan for files           |
+| `exclude_directories` | regex expression of directories to exclude from walking |
+| `exclude_files`       | regex expression of files to exclude from tracking      |
 
 ### \[emit\]
 

--- a/smoketest/smoketest.ini
+++ b/smoketest/smoketest.ini
@@ -29,7 +29,6 @@ config.type = smoketest
 # Metric names cannot contain spaces or commas.
 metric_name = smoketest_watcher
 root_directories = smoketest_queues
-remove_prefix =
 
 # Exclude directories and files from being watched.
 # The following are regular expressions and are matched against the full path.

--- a/src/walk_watcher/watcher.py
+++ b/src/walk_watcher/watcher.py
@@ -154,7 +154,6 @@ class Watcher:
             A tuple of directories and files.
         """
         target_directories = self._config.root_directories
-        remove_prefix = self._config.remove_prefix
 
         files: list[File] = []
         directories: list[Directory] = []
@@ -164,9 +163,6 @@ class Watcher:
 
             for dirpath, _, filenames in os.walk(root):
                 now = int(datetime.now().timestamp())
-                if remove_prefix:
-                    dirpath = dirpath.lstrip(remove_prefix)
-                    dirpath = dirpath or "/"
 
                 directories.append(Directory(dirpath, now, len(filenames)))
                 files.extend([File(dirpath, filename, now) for filename in filenames])

--- a/src/walk_watcher/watcherconfig.py
+++ b/src/walk_watcher/watcherconfig.py
@@ -35,7 +35,6 @@ config.file.name = {filename}
 # Metric names cannot contain spaces or commas.
 metric_name = file.watcher
 root_directories =
-remove_prefix =
 
 # Exclude directories and files from being watched.
 # The following are regular expressions and are matched against the full path.
@@ -123,11 +122,6 @@ class WatcherConfig:
         config_line = self._config.get("watcher", "root_directories")
         lines = [line.strip() for line in config_line.split("\n") if line.strip()]
         return lines
-
-    @property
-    def remove_prefix(self) -> str | None:
-        """Return the prefix to remove from the root directory when reporting."""
-        return self._config.get("watcher", "remove_prefix", fallback=None)
 
     @property
     def exclude_directory_pattern(self) -> str | None:

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -25,7 +25,6 @@ metric_name = test_watcher
 root_directories =
     tests/fixture
     tests/mock_directory
-remove_prefix = tests/
 
 # Exclude directories and files from being watched.
 # The following are regular expressions and are matched against the full path.

--- a/tests/watcher_test.py
+++ b/tests/watcher_test.py
@@ -29,25 +29,7 @@ def watcher() -> Watcher:
     return Watcher(config)
 
 
-def test_walk_directory_strip_root(watcher: Watcher) -> None:
-    cwd = os.getcwd()
-    root = os.path.join(cwd, "tests/fixture")
-
-    with patch.object(watcher._config, "root_directory", root):
-        with patch.object(watcher._config, "remove_prefix", cwd):
-            all_directories, all_files = watcher._walk_directories()
-
-    assert len(all_directories) == 3
-    assert len(all_files) == 3
-
-    for directory in all_directories:
-        assert not directory.root.startswith(root)
-
-    for file in all_files:
-        assert not file.root.startswith(root)
-
-
-def test_walk_directory_keep_root(watcher: Watcher) -> None:
+def test_walk_directory(watcher: Watcher) -> None:
     cwd = os.getcwd()
     root = os.path.join(cwd, "tests/fixture")
 

--- a/tests/watcherconfig_test.py
+++ b/tests/watcherconfig_test.py
@@ -33,7 +33,6 @@ def test_watcherconfig_loads_test_fixture_completely() -> None:
 
     assert config.metric_name == "test_watcher"
     assert config.root_directories == ["tests/fixture", "tests/mock_directory"]
-    assert config.remove_prefix == "tests/"
 
     assert config.exclude_directory_pattern == r"\/directory02|fixture$|\\directory02"
     assert config.exclude_file_pattern == "file01.*"


### PR DESCRIPTION
This feature's request is meant with the definition of the `root_directories`.