### PR TITLE
Remove age based cleanup configuration items

### DIFF
--- a/smoketest/smoketest.ini
+++ b/smoketest/smoketest.ini
@@ -4,8 +4,6 @@ config_name = smoketest
 
 # :memory: can be used here to use an in-memory database.
 database_path = smoketest.db
-oldest_directory_row_days = 14
-oldest_file_row_days = 14
 
 # Controls how long the is_running flag is valid for.
 max_is_running_seconds = 10
@@ -17,7 +15,7 @@ max_emit_line_count = 500
 # Intervals are only used when running with the `--loop` flag.
 # Intervals are in seconds.
 collect_interval = 5
-emit_interval = 10
+emit_interval = 60
 
 [dimensions]
 # Dimensions are optional and can be used to add additional context to the metric.

--- a/src/walk_watcher/watcherconfig.py
+++ b/src/walk_watcher/watcherconfig.py
@@ -11,8 +11,6 @@ config_name = {filename}
 
 # :memory: can be used here to use an in-memory database.
 database_path = {filename}
-oldest_directory_row_days = 14
-oldest_file_row_days = 14
 
 # Controls how long the is_running flag is valid for.
 max_is_running_seconds = 60
@@ -91,16 +89,6 @@ class WatcherConfig:
     def max_is_running_seconds(self) -> int:
         """Return the maximum age of the is_running flag in seconds."""
         return self._config.getint("system", "max_is_running_seconds", fallback=300)
-
-    @property
-    def oldest_directory_row_days(self) -> int:
-        """Return the maximum age of a directory row in days."""
-        return self._config.getint("system", "oldest_directory_row_days", fallback=30)
-
-    @property
-    def oldest_file_row_days(self) -> int:
-        """Return the maximum age of a file row in days."""
-        return self._config.getint("system", "oldest_file_row_days", fallback=30)
 
     @property
     def max_emit_line_count(self) -> int:

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -2,8 +2,6 @@
 # config_name should be unique for each configuration file.
 config_name = test_watcher
 database_path = :memory:
-oldest_directory_row_days = 14
-oldest_file_row_days = 14
 max_is_running_seconds = 60
 max_emit_line_count = 1000
 

--- a/tests/watcherconfig_test.py
+++ b/tests/watcherconfig_test.py
@@ -22,8 +22,6 @@ def test_watcherconfig_loads_test_fixture_completely() -> None:
 
     assert config.config_name == "test_watcher"
     assert config.database_path == ":memory:"
-    assert config.oldest_directory_row_days == 14
-    assert config.oldest_file_row_days == 14
 
     assert config.max_is_running_seconds == 60
     assert config.max_emit_line_count == 1000

--- a/tests/watcherstore_test.py
+++ b/tests/watcherstore_test.py
@@ -64,8 +64,6 @@ def test_storedb_built_from_config() -> None:
     store_db = WatcherStore.from_config(config)
 
     assert store_db._max_is_running_age == 1
-    assert store_db._oldest_directory_row_age == 2
-    assert store_db._oldest_file_row_age == 3
 
 
 def test_storedb_works_with_context_manager() -> None:
@@ -272,8 +270,8 @@ def test_get_oldest_files(store_db_full: WatcherStore) -> None:
     assert rows[1].filename == "file1"
 
 
-def test_clean_oldest_files(store_db_full: WatcherStore) -> None:
-    store_db_full.clean_oldest_files()
+def test_clean_removed_files(store_db_full: WatcherStore) -> None:
+    store_db_full.clean_removed_files()
 
     cursor = store_db_full._connection.cursor()
     cursor.execute("SELECT * FROM files")


### PR DESCRIPTION
The database store will no longer retain file rows for N days. Any file row that is marked removed in the table will be deleted on exit of the database context manager.