### PR TITLE
Enhance how first_seen is gathered for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ milliseconds. This should be compatible with most ingest agents.
 - telegraf agent
 - Dynatrace OneAgent
 
+## Limitation: file age
+
+As this was designed to track files moving through a queue of directories is it
+assumed that the file is being moved instead of being created new. Because of
+this there is a limitation on determining the age of the file. While linux
+systems will return the last time a file was moved in the modified date of the
+file, Windows systems do not. In fact, there is no easy way to get that
+information from a Windows filesystem.
+
+Because of this, file age is based on the first time the watcher sees the file
+and not when the file was created. This means that on startup the file ages will
+not be as accurate as they are after the watcher has been running. The length of
+time for the accuracy to increase depends on the rate at which the files move
+through the directory queues.
+
+This default behavior can altered with the configration file. By setting
+`treat_files_as_new = true` the first seen timestamp will look at the file
+creation time.
+
 ## Installation
 
 ```console

--- a/src/walk_watcher/watcherconfig.py
+++ b/src/walk_watcher/watcherconfig.py
@@ -18,6 +18,9 @@ max_is_running_seconds = 60
 # Controls how many lines are emitted in a single batch.
 max_emit_line_count = 500
 
+# If true, file age is based on creation time (see README.md)
+treat_files_as_new = false
+
 [intervals]
 # Intervals are only used when running with the `--loop` flag.
 # Intervals are in seconds.
@@ -94,6 +97,11 @@ class WatcherConfig:
     def max_emit_line_count(self) -> int:
         """Return the maximum number of lines to emit at once."""
         return self._config.getint("system", "max_emit_line_count", fallback=500)
+
+    @property
+    def treat_files_as_new(self) -> bool:
+        """Return the flag for how first_seen timestamps are calculated."""
+        return self._config.getboolean("system", "treat_files_as_new", fallback=False)
 
     @property
     def collect_interval(self) -> int:

--- a/src/walk_watcher/watcherstore.py
+++ b/src/walk_watcher/watcherstore.py
@@ -206,7 +206,7 @@ class WatcherStore:
                 (
                     file.root,
                     file.filename,
-                    file.last_seen,
+                    file.first_seen,
                     file.last_seen,
                 )
                 for file in files

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -4,6 +4,7 @@ config_name = test_watcher
 database_path = :memory:
 max_is_running_seconds = 60
 max_emit_line_count = 1000
+treat_files_as_new = true
 
 [intervals]
 # Intervals are only used when running with the `--loop` flag.

--- a/tests/watcherconfig_test.py
+++ b/tests/watcherconfig_test.py
@@ -26,6 +26,8 @@ def test_watcherconfig_loads_test_fixture_completely() -> None:
     assert config.max_is_running_seconds == 60
     assert config.max_emit_line_count == 1000
 
+    assert config.treat_files_as_new is True
+
     assert config.collect_interval == 5
     assert config.emit_interval == 20
 

--- a/tests/watcherstore_test.py
+++ b/tests/watcherstore_test.py
@@ -167,7 +167,7 @@ def test_save_files_empty_rows(store_db: WatcherStore) -> None:
         == (
             file.root,
             file.filename,
-            file.last_seen,
+            file.first_seen,
             file.last_seen,
             0,
             0,
@@ -178,9 +178,9 @@ def test_save_files_empty_rows(store_db: WatcherStore) -> None:
 
 def test_save_file_existing_row_updated(store_db: WatcherStore) -> None:
     files = [
-        File("/home/user/magamind", "file1", 1618224000),
-        File("/home/user/magamind", "file2", 1618224000),
-        File("/home/user/magamind", "file3", 1618224000),
+        File("/home/user/magamind", "file1", 1618224000, 1618224000),
+        File("/home/user/magamind", "file2", 1618224000, 1618224000),
+        File("/home/user/magamind", "file3", 1618224000, 1618224000),
     ]
     print("first files", files[-1])
     store_db.save_files(files)
@@ -225,7 +225,7 @@ def test_save_file_add_new_row_with_existing_rows(store_db: WatcherStore) -> Non
     assert last_row[1:] == (
         new_file.root,
         new_file.filename,
-        new_file.last_seen,
+        new_file.first_seen,
         new_file.last_seen,
         0,
         0,


### PR DESCRIPTION
Allow the use of ctime in place of the current time for `first_seen`.
ctime is not optimal for Windows systems if the files in the queue are
being moved versus newly created through each directory (queue).
`treat_files_as_new` flag in the configuration file allows this option
to be toggled.
