### PR TITLE
Calculate file age on insertion

### DIFF
--- a/src/walk_watcher/watcher.py
+++ b/src/walk_watcher/watcher.py
@@ -190,7 +190,6 @@ class Watcher:
 
     def _get_first_seen(self, filepath: str, now: int) -> int:
         """Return the int timestamp of when the file is first seen."""
-        # TODO: test this
         if self._config.treat_files_as_new:
             # Files are newly created between queues, safe to use ctime for timestamp
             return int(os.path.getctime(filepath))

--- a/src/walk_watcher/watcherstore.py
+++ b/src/walk_watcher/watcherstore.py
@@ -200,7 +200,7 @@ class WatcherStore:
             """
             INSERT OR IGNORE INTO files (root, filename, first_seen,
                 last_seen, age_seconds, removed)
-            VALUES (?, ?, ?, ?, 0, 0)
+            VALUES (?, ?, ?, ?, ?, 0)
             """,
             [
                 (
@@ -208,6 +208,7 @@ class WatcherStore:
                     file.filename,
                     file.first_seen,
                     file.last_seen,
+                    file.last_seen - file.first_seen,
                 )
                 for file in files
             ],

--- a/tests/watcherstore_test.py
+++ b/tests/watcherstore_test.py
@@ -169,7 +169,7 @@ def test_save_files_empty_rows(store_db: WatcherStore) -> None:
             file.filename,
             file.first_seen,
             file.last_seen,
-            0,
+            file.last_seen - file.first_seen,
             0,
         )
         for row, file in zip(rows, files)
@@ -227,7 +227,7 @@ def test_save_file_add_new_row_with_existing_rows(store_db: WatcherStore) -> Non
         new_file.filename,
         new_file.first_seen,
         new_file.last_seen,
-        0,
+        new_file.last_seen - new_file.first_seen,
         0,
     )
 


### PR DESCRIPTION
Correctly calculate the file age at insertion instead of defaulting to 0 seconds.