### PR TITLE
Generate directory size in bytes metric lines

### DIFF
--- a/src/walk_watcher/watcher.py
+++ b/src/walk_watcher/watcher.py
@@ -189,13 +189,17 @@ class Watcher:
         return files
 
     def _get_first_seen(self, filepath: str, now: int) -> int:
-        """Return the int timestamp of when the file is first seen."""
+        """
+        Defaults to returning now. If treat_files_as_new is set, returns ctime().
+
+        Raises:
+            FileNotFoundError
+        """
         if self._config.treat_files_as_new:
             # Files are newly created between queues, safe to use ctime for timestamp
             return int(os.path.getctime(filepath))
 
         # Files are moved between queues, Windows fails to report ctime correctly
-        # Use now in place of ctime.
         return now
 
     @staticmethod

--- a/src/walk_watcher/watcher.py
+++ b/src/walk_watcher/watcher.py
@@ -169,6 +169,7 @@ class Watcher:
             filepath = os.path.join(dirpath, filename)
             try:
                 firstseen = self._get_first_seen(filepath, now)
+                size_in_bytes = self._get_file_size_in_bytes(filepath)
 
             except FileNotFoundError:
                 # The file has been moved after the walk completed
@@ -179,8 +180,9 @@ class Watcher:
                 File(
                     root=dirpath,
                     filename=filename,
-                    last_seen=now,
                     first_seen=firstseen,
+                    last_seen=now,
+                    size_bytes=size_in_bytes,
                 )
             )
 
@@ -201,6 +203,15 @@ class Watcher:
 
         # Files are moved between queues, Windows fails to report ctime correctly
         return now
+
+    def _get_file_size_in_bytes(self, filepath: str) -> int:
+        """
+        Return the reported file size of the file.
+
+        Raises:
+            FileNotFoundError
+        """
+        return os.path.getsize(filepath)
 
     @staticmethod
     def _sanitize_directory_path(path: str) -> str:

--- a/src/walk_watcher/watchermodel.py
+++ b/src/walk_watcher/watchermodel.py
@@ -19,8 +19,9 @@ class File:
 
     root: str
     filename: str
+    first_seen: int
     last_seen: int
-    first_seen: int = 0
+    size_bytes: int = 0
     age_seconds: int = 0
     removed: int = 0
 
@@ -30,6 +31,6 @@ class File:
 
         return (
             f"{self.root}/{self.filename}"
-            f" ({self.age_seconds} seconds old, last seen {lastseen})"
+            f" ({self.age_seconds} seconds old, {self.size_bytes} bytes, last seen {lastseen})"
             f" {'(removed)' if self.removed else '(present)'}"
         )

--- a/tests/watcher_test.py
+++ b/tests/watcher_test.py
@@ -160,10 +160,7 @@ def test_build_file_models_file_not_found(watcher: Watcher) -> None:
     ]
     dirpath = "./tests"
 
-    # When treat_files_as_new is false the getctime() call is skipped
-    # TODO: remove this override when we are gathering file size as well
-    with patch.object(watcher._config, "treat_files_as_new", True):
-        result = watcher._build_file_models(dirpath, filenames)
+    result = watcher._build_file_models(dirpath, filenames)
 
     assert len(result) == 1
 

--- a/tests/watchermodel_test.py
+++ b/tests/watchermodel_test.py
@@ -6,10 +6,10 @@ from walk_watcher.watchermodel import File
 
 
 def test_model_file_str() -> None:
-    file_present = File("/foo/bar", "baz.txt", 1234568190, 1234567890, 300, 0)
-    file_removed = File("/foo/bar", "baz.txt", 1234568190, 1234567890, 300, 1)
+    file_present = File("/foo/bar", "baz.txt", 1234567890, 1234568190, 100, 300, 0)
+    file_removed = File("/foo/bar", "baz.txt", 1234567890, 1234568190, 100, 300, 1)
     expected_ts = datetime.fromtimestamp(1234568190).strftime("%Y-%m-%d %H:%M:%S")
-    expected = f"/foo/bar/baz.txt (300 seconds old, last seen {expected_ts})"
+    expected = f"/foo/bar/baz.txt (300 seconds old, 100 bytes, last seen {expected_ts})"
     expected_preset = "(present)"
     expected_removed = "(removed)"
 


### PR DESCRIPTION
Capture the size of files captured in walk and use their sum to determine size of directory. Do not capture size of directory directly as there may be ignored sub directories or files included.