### PR TITLE
Update smoke test

### DIFF
--- a/smoketest/smoketest.ini
+++ b/smoketest/smoketest.ini
@@ -11,11 +11,14 @@ max_is_running_seconds = 10
 # Controls how many lines are emitted in a single batch.
 max_emit_line_count = 500
 
+# If true, file age is based on creation time (see README.md)
+treat_files_as_new = true
+
 [intervals]
 # Intervals are only used when running with the `--loop` flag.
 # Intervals are in seconds.
-collect_interval = 5
-emit_interval = 60
+collect_interval = 30
+emit_interval = 30
 
 [dimensions]
 # Dimensions are optional and can be used to add additional context to the metric.


### PR DESCRIPTION
Add a redrive to the deadletter with 15 minute default rotation.

Slow down redrive on retry queues to 2 minutes