### PR TITLE
Filter files and directories during walk

### DIFF
--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -28,7 +28,8 @@ root_directories =
 # Exclude directories and files from being watched.
 # The following are regular expressions and are matched against the full path.
 # Multiline values are combined into a single regular expression.
-exclude_directories = \/directory02
+exclude_directories =
+    \/directory02
     fixture$
     \\directory02
 


### PR DESCRIPTION
Move filters of excluded file and directory patterns to the walk loops. This will reduce some of the time spent fetching ctime and file size.